### PR TITLE
Add Stripe checkout button component

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import VoLogo from "./components/VoLogo.jsx";
+import StripeCheckoutButton from "./components/StripeCheckoutButton.jsx";
 import "./App.scss";
 
 function ActionButton({ children, variant = "primary" }) {
@@ -20,7 +21,7 @@ export default function App() {
           </div>
           <p className="hero__tagline">A screen reader you don't have to learn</p>
           <div className="hero__cta-group" role="group" aria-label="Primary actions">
-            <ActionButton variant="primary">Buy Now</ActionButton>
+            <StripeCheckoutButton />
             <ActionButton variant="secondary">Video</ActionButton>
           </div>
         </header>

--- a/src/components/StripeCheckoutButton.jsx
+++ b/src/components/StripeCheckoutButton.jsx
@@ -1,0 +1,25 @@
+const DEFAULT_CHECKOUT_URL =
+  import.meta.env.VITE_STRIPE_CHECKOUT_URL ??
+  "https://buy.stripe.com/test_9AQ8ynflpa9lc7GeUU";
+
+export default function StripeCheckoutButton({
+  label = "Buy Now",
+  checkoutUrl,
+}) {
+  const targetUrl = checkoutUrl ?? DEFAULT_CHECKOUT_URL;
+
+  const handleClick = () => {
+    window.location.assign(targetUrl);
+  };
+
+  return (
+    <button
+      type="button"
+      className="action-button action-button--primary"
+      onClick={handleClick}
+      aria-label={label}
+    >
+      {label}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- add a dedicated StripeCheckoutButton component that redirects to a checkout URL
- swap the hero Buy Now button to use the Stripe checkout component

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d30bf8309883339d7d3e30dfc4a14c