### PR TITLE
Update primary CTA to waitlist form

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -35,7 +35,7 @@ export default function App() {
               target="_blank"
               rel="noopener noreferrer"
             >
-              <ActionButton variant="primary">waitlist</ActionButton>
+              <ActionButton variant="primary">Waitlist</ActionButton>
             </a>
             <a
               href="https://www.youtube.com/watch?v=LC5k0qVJHwA"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -30,7 +30,13 @@ export default function App() {
             role="group"
             aria-label="Primary actions"
           >
-            <ActionButton variant="primary">Buy Now</ActionButton>
+            <a
+              href="https://docs.google.com/forms/d/e/1FAIpQLSebloM9bIN8uJ-7qQmRnDuG-WNovoJiwKSYTnlHkgGD6hElsw/viewform?usp=header"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <ActionButton variant="primary">waitlist</ActionButton>
+            </a>
             <a
               href="https://www.youtube.com/watch?v=LC5k0qVJHwA"
               target="_blank"


### PR DESCRIPTION
## Summary
- replace the Buy Now primary CTA with a waitlist link that opens the Google Form

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6cba3d3488333b6dff0722a6c20e3