### PR TITLE
Add about section highlighting VoNav vision

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -81,6 +81,32 @@ export default function App() {
             </ul>
           </div>
         </section>
+
+        <section className="about" aria-labelledby="about-heading">
+          <div className="about__content">
+            <h2 id="about-heading">Why we built VoNav</h2>
+            <p>
+              We built VoNav because screen readers feel like they're stuck decades in the
+              past. We wanted something that felt like talking to your friend as they help
+              you with your computer. Your friend wouldn't make you memorize a whole new
+              language just to talk with you, so we don't expect that either. Your friend
+              wouldn't skip half the page, or give up on an image, so we do our best to meet
+              that.
+            </p>
+            <p>
+              VoNav is really just our vision to bring screen readers to 2025. We don't want
+              this to feel like just another screen reader, but a completely different way of
+              using your computer. We're definitely going to have hiccups. It's not going to
+              start off perfect. But if we don't build this, screen readers aren't going to
+              improve themselves.
+            </p>
+            <p>
+              We hope you love VoNav: a voice-first way to navigate your computer that’s
+              fast, natural, and kind of magical. No steep learning curve. No robotic menus.
+              Just you, talking to your machine like it’s 2025.
+            </p>
+          </div>
+        </section>
       </main>
 
       <footer className="footer" role="contentinfo">

--- a/src/App.scss
+++ b/src/App.scss
@@ -209,6 +209,50 @@ main {
   }
 }
 
+.about {
+  width: 100%;
+  max-width: $page-max-width;
+  background: rgba(16, 6, 28, 0.82);
+  border: 1px solid rgba(125, 45, 157, 0.45);
+  border-radius: 32px;
+  padding: clamp(2.2rem, 4.5vw, 3.4rem);
+  position: relative;
+  overflow: hidden;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04), 0 28px 52px rgba(10, 4, 18, 0.5);
+
+  &::after {
+    content: "";
+    position: absolute;
+    inset: auto -20% -25% auto;
+    width: 380px;
+    height: 380px;
+    background: radial-gradient(circle, rgba(253, 217, 44, 0.32), rgba(231, 134, 103, 0));
+    filter: blur(22px);
+    opacity: 0.65;
+  }
+
+  &__content {
+    position: relative;
+    z-index: 1;
+    display: grid;
+    gap: 1.5rem;
+  }
+
+  h2 {
+    font-family: "Baron", "Poppins", sans-serif;
+    font-size: clamp(2rem, 4vw, 2.6rem);
+    letter-spacing: 0.06em;
+    color: white;
+  }
+
+  p {
+    font-size: clamp(1.05rem, 2.3vw, 1.3rem);
+    line-height: 1.7;
+    color: rgba(255, 255, 255, 0.85);
+    max-width: 70ch;
+  }
+}
+
 .footer {
   width: 100%;
   max-width: $page-max-width;


### PR DESCRIPTION
## Summary
- add an About section describing VoNav's mission near the bottom of the landing page
- style the new section to match the existing visual theme with gradients and soft lighting

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6cfd241d0833399d2bee99cd72009